### PR TITLE
feat: add `--cfg-cdn-base` to set custom cname

### DIFF
--- a/abstract/Block.js
+++ b/abstract/Block.js
@@ -149,6 +149,7 @@ export class Block extends BaseComponent {
         '--cfg-init-activity',
         '--cfg-done-activity',
         '--cfg-max-local-file-size-bytes',
+        '--cfg-cdn-base',
       ];
       cfgProps.forEach((prop) => {
         this.bindCssData(prop);

--- a/abstract/Block.js
+++ b/abstract/Block.js
@@ -149,7 +149,7 @@ export class Block extends BaseComponent {
         '--cfg-init-activity',
         '--cfg-done-activity',
         '--cfg-max-local-file-size-bytes',
-        '--cfg-cdn-base',
+        '--cfg-cdn-cname',
       ];
       cfgProps.forEach((prop) => {
         this.bindCssData(prop);

--- a/blocks/CloudImageEditor/src/CloudEditor.js
+++ b/blocks/CloudImageEditor/src/CloudEditor.js
@@ -1,4 +1,5 @@
 import { Block } from '../../../abstract/Block.js';
+import { createOriginalUrl } from '../../../utils/cdn-utils.js';
 import { classNames } from './lib/classNames.js';
 import { debounce } from './lib/debounce.js';
 import { preloadImage } from './lib/preloadImage.js';
@@ -120,8 +121,7 @@ export class CloudEditor extends Block {
       return;
     }
 
-    // TODO: fix hardcode
-    this.$['*originalUrl'] = `https://ucarecdn.com/${this.$.uuid}/`;
+    this.$['*originalUrl'] = createOriginalUrl(this.$['*--cfg-cdn-base'], this.$.uuid);
 
     fetch(`${this.$['*originalUrl']}-/json/`)
       .then((response) => response.json())

--- a/blocks/CloudImageEditor/src/CloudEditor.js
+++ b/blocks/CloudImageEditor/src/CloudEditor.js
@@ -121,7 +121,7 @@ export class CloudEditor extends Block {
       return;
     }
 
-    this.$['*originalUrl'] = createOriginalUrl(this.$['*--cfg-cdn-base'], this.$.uuid);
+    this.$['*originalUrl'] = createOriginalUrl(this.$['*--cfg-cdn-cname'], this.$.uuid);
 
     fetch(`${this.$['*originalUrl']}-/json/`)
       .then((response) => response.json())

--- a/blocks/CloudImageEditor/src/EditorImageCropper.js
+++ b/blocks/CloudImageEditor/src/EditorImageCropper.js
@@ -65,7 +65,7 @@ function validateCrop(crop) {
  * }} State
  */
 
-/** @extends {Block<State>} */
+/** @extends {Block<State & import('./CloudEditor.js').State>} */
 export class EditorImageCropper extends Block {
   init$ = {
     image: null,
@@ -464,7 +464,7 @@ export class EditorImageCropper extends Block {
       .then(() => image)
       .catch((err) => {
         console.error('Failed to load image', { error: err });
-        this.$['*networProblems'] = true;
+        this.$['*networkProblems'] = true;
         return Promise.resolve(image);
       });
   }

--- a/blocks/FileItem/FileItem.js
+++ b/blocks/FileItem/FileItem.js
@@ -4,6 +4,7 @@ import { uploadFile } from '../../submodules/upload-client/upload-client.js';
 import { UiMessage } from '../MessageBox/MessageBox.js';
 import { fileCssBg } from '../svg-backgrounds/svg-backgrounds.js';
 import { customUserAgent } from '../utils/userAgent.js';
+import { createCdnUrl, createCdnUrlModifiers, createOriginalUrl } from '../../utils/cdn-utils.js';
 
 /** @typedef {Partial<import('../MessageBox/MessageBox.js').State>} ExternalState */
 
@@ -174,10 +175,13 @@ export class FileItem extends Block {
         this.setAttribute('loaded', '');
 
         if (this.entry.getValue('isImage')) {
-          let url = `https://ucarecdn.com/${uuid}/`;
           this._revokeThumbUrl();
           let size = this.$['*--cfg-thumb-size'] || 76;
-          this.$.thumbUrl = `url(${url}-/scale_crop/${size}x${size}/center/)`;
+          let thumbUrl = createCdnUrl(
+            createOriginalUrl(this.$['*--cfg-cdn-base'], uuid),
+            createCdnUrlModifiers(`scale_crop/${size}x${size}/center`)
+          );
+          this.$.thumbUrl = `url(${thumbUrl})`;
         }
       });
 
@@ -188,7 +192,8 @@ export class FileItem extends Block {
         if (this.entry.getValue('isImage')) {
           this._revokeThumbUrl();
           let size = this.$['*--cfg-thumb-size'] || 76;
-          this.$.thumbUrl = `url(${cdnUrl}-/scale_crop/${size}x${size}/center/)`;
+          let thumbUrl = createCdnUrl(cdnUrl, createCdnUrlModifiers(`scale_crop/${size}x${size}/center`));
+          this.$.thumbUrl = `url(${thumbUrl})`;
         }
       });
 
@@ -259,6 +264,7 @@ export class FileItem extends Block {
       let fileInfo = await uploadFile(this.file || this.externalUrl, {
         ...storeSetting,
         publicKey: this.$['*--cfg-pubkey'],
+        baseCDN: this.$['*--cfg-cdn-base'],
         userAgent: customUserAgent,
         fileName: this.entry.getValue('fileName'),
         onProgress: (progress) => {

--- a/blocks/FileItem/FileItem.js
+++ b/blocks/FileItem/FileItem.js
@@ -178,7 +178,7 @@ export class FileItem extends Block {
           this._revokeThumbUrl();
           let size = this.$['*--cfg-thumb-size'] || 76;
           let thumbUrl = createCdnUrl(
-            createOriginalUrl(this.$['*--cfg-cdn-base'], uuid),
+            createOriginalUrl(this.$['*--cfg-cdn-cname'], uuid),
             createCdnUrlModifiers(`scale_crop/${size}x${size}/center`)
           );
           this.$.thumbUrl = `url(${thumbUrl})`;
@@ -264,7 +264,7 @@ export class FileItem extends Block {
       let fileInfo = await uploadFile(this.file || this.externalUrl, {
         ...storeSetting,
         publicKey: this.$['*--cfg-pubkey'],
-        baseCDN: this.$['*--cfg-cdn-base'],
+        baseCDN: this.$['*--cfg-cdn-cname'],
         userAgent: customUserAgent,
         fileName: this.entry.getValue('fileName'),
         onProgress: (progress) => {

--- a/blocks/Img/ImgBase.js
+++ b/blocks/Img/ImgBase.js
@@ -2,6 +2,8 @@ import { BaseComponent } from '../../submodules/symbiote/core/symbiote.js';
 import { createCdnUrl, createCdnUrlModifiers, createOriginalUrl } from '../../utils/cdn-utils.js';
 import { PROPS_MAP } from './props-map.js';
 
+// TODO: move default config values somewhere outside
+const DEFAULT_CDN_BASE = 'https://ucarecdn.com';
 const CSS_PREF = '--uc-img-';
 const UNRESOLVED_ATTR = 'unresolved';
 const HI_RES_K = 2;
@@ -95,7 +97,7 @@ export class ImgBase extends BaseComponent {
     if (this.$$('uuid')) {
       return createCdnUrl(
         //
-        createOriginalUrl('https://ucarecdn.com/', this.$$('uuid')),
+        createOriginalUrl(this.$$['cdn-base'] || DEFAULT_CDN_BASE, this.$$('uuid')),
         cdnModifiers
       );
     }

--- a/blocks/Img/ImgBase.js
+++ b/blocks/Img/ImgBase.js
@@ -97,7 +97,7 @@ export class ImgBase extends BaseComponent {
     if (this.$$('uuid')) {
       return createCdnUrl(
         //
-        createOriginalUrl(this.$$['cdn-base'] || DEFAULT_CDN_BASE, this.$$('uuid')),
+        createOriginalUrl(this.$$['cdn-cname'] || DEFAULT_CDN_BASE, this.$$('uuid')),
         cdnModifiers
       );
     }

--- a/blocks/UploadDetails/UploadDetails.js
+++ b/blocks/UploadDetails/UploadDetails.js
@@ -125,7 +125,7 @@ export class UploadDetails extends Block {
         if (uuid) {
           this.eCanvas.clear();
           this.set$({
-            cdnUrl: createOriginalUrl(this.$['*--cfg-cdn-base'], uuid),
+            cdnUrl: createOriginalUrl(this.$['*--cfg-cdn-cname'], uuid),
             cloudEditBtnHidden: !this.entry.getValue('isImage') || !this.$['*--cfg-use-cloud-image-editor'],
           });
           this.entry.getValue('isImage') && this.eCanvas.setImageUrl(this.$.cdnUrl);

--- a/blocks/UploadDetails/UploadDetails.js
+++ b/blocks/UploadDetails/UploadDetails.js
@@ -1,4 +1,5 @@
 import { Block } from '../../abstract/Block.js';
+import { createOriginalUrl } from '../../utils/cdn-utils.js';
 import { fileCssBg } from '../svg-backgrounds/svg-backgrounds.js';
 
 /**
@@ -124,7 +125,7 @@ export class UploadDetails extends Block {
         if (uuid) {
           this.eCanvas.clear();
           this.set$({
-            cdnUrl: `https://ucarecdn.com/${uuid}/`,
+            cdnUrl: createOriginalUrl(this.$['*--cfg-cdn-base'], uuid),
             cloudEditBtnHidden: !this.entry.getValue('isImage') || !this.$['*--cfg-use-cloud-image-editor'],
           });
           this.entry.getValue('isImage') && this.eCanvas.setImageUrl(this.$.cdnUrl);

--- a/blocks/themes/uc-basic/config.css
+++ b/blocks/themes/uc-basic/config.css
@@ -31,4 +31,5 @@
   --cfg-data-output-form-value: 1;
 
   --cfg-remote-tab-session-key: '';
+  --cfg-cdn-base: 'https://ucarecdn.com';
 }

--- a/blocks/themes/uc-basic/config.css
+++ b/blocks/themes/uc-basic/config.css
@@ -31,5 +31,5 @@
   --cfg-data-output-form-value: 1;
 
   --cfg-remote-tab-session-key: '';
-  --cfg-cdn-base: 'https://ucarecdn.com';
+  --cfg-cdn-cname: 'https://ucarecdn.com';
 }

--- a/css-types.js
+++ b/css-types.js
@@ -2,6 +2,8 @@
  * @typedef {{
  *   '*--cfg-pubkey': String;
  *   '*--cfg-multiple': Number;
+ *   '*--cfg-multiple-min': Number;
+ *   '*--cfg-multiple-max': Number;
  *   '*--cfg-confirm-upload': Number;
  *   '*--cfg-img-only': Number;
  *   '*--cfg-accept': String;
@@ -13,8 +15,6 @@
  *   '*--cfg-show-empty-list': Number;
  *   '*--cfg-use-local-image-editor': Number;
  *   '*--cfg-use-cloud-image-editor': Number;
- *   '*--cfg-multiple-min': Number;
- *   '*--cfg-multiple-max': Number;
  *   '*--cfg-modal-scroll-lock': Number;
  *   '*--cfg-modal-backdrop-strokes': Number;
  *   '*--cfg-source-list-wrap': Number;
@@ -25,6 +25,7 @@
  *   '*--cfg-data-output-from': String;
  *   '*--cfg-data-output-form-value': Number;
  *   '*--cfg-remote-tab-session-key': String;
+ *   '*--cfg-cdn-base': String;
  * }} CssConfigTypes
  */
 export {};

--- a/css-types.js
+++ b/css-types.js
@@ -25,7 +25,7 @@
  *   '*--cfg-data-output-from': String;
  *   '*--cfg-data-output-form-value': Number;
  *   '*--cfg-remote-tab-session-key': String;
- *   '*--cfg-cdn-base': String;
+ *   '*--cfg-cdn-cname': String;
  * }} CssConfigTypes
  */
 export {};

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -52,24 +52,25 @@ Any configuration value can be defined and redefined at any level of the DOM tre
 
 ## Parameters description
 
-| Name                              | Description                                                                                                                            |         Values         | Default |
-| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | :--------------------: | :-----: |
-| `--cfg-pubkey`                    | Your project Public Key                                                                                                                |   `'demopublickey'`    |  none   |
-| `--cfg-multiple`                  | Allow to upload multiple files                                                                                                         |       `1` or `0`       |   `1`   |
-| `--cfg-multiple-min`              | Minimum number of files that can be selected.                                                                                          |         number         |  none   |
-| `--cfg-multiple-max`              | Maximum number of files that can be selected.                                                                                          |         number         |  none   |
-| `--cfg-confirm-upload`            | Enables user confirmation for upload starting                                                                                          |       `1` or `0`       |   `1`   |
-| `--cfg-img-only`                  | Accept images only                                                                                                                     |       `1` or `0`       |   `0`   |
-| `--cfg-accept`                    | Native file input accept attribute value                                                                                               |      `'image/*'`       |  none   |
-| `--cfg-store`                     | Store files                                                                                                                            |       `1` or `0`       |    -    |
-| `--cfg-camera-mirror`             | Flip camera image                                                                                                                      |       `1` or `0`       |   `0`   |
-| `--cfg-source-list`               | Comma-separated list of file sources                                                                                                   | `'local, url, camera'` |  none   |
-| `--cfg-max-local-file-size-bytes` | Maximum file size in bytes                                                                                                             |           -            |  none   |
-| `--cfg-thumb-size`                | Image thumbnail size                                                                                                                   |          `76`          |  `76`   |
-| `--cfg-show-empty-list`           | Show uploads list when it's empty                                                                                                      |       `1` or `0`       |   `0`   |
-| `--cfg-use-local-image-editor`    | Enable local image editing                                                                                                             |       `1` or `0`       |   `0`   |
-| `--cfg-use-cloud-image-editor`    | Enable cloud image editing                                                                                                             |       `1` or `0`       |   `0`   |
-| `--cfg-remote-tab-session-key`    | Key to revoke Custom OAuth access. See [docs](https://uploadcare.com/docs/start/settings/#project-settings-advanced-oauth) for details |         string         |  none   |
+| Name                              | Description                                                                                                                            |         Values         |        Default         |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | :--------------------: | :--------------------: |
+| `--cfg-pubkey`                    | Your project Public Key                                                                                                                |   `'demopublickey'`    |          none          |
+| `--cfg-multiple`                  | Allow to upload multiple files                                                                                                         |       `1` or `0`       |          `1`           |
+| `--cfg-multiple-min`              | Minimum number of files that can be selected.                                                                                          |         number         |          none          |
+| `--cfg-multiple-max`              | Maximum number of files that can be selected.                                                                                          |         number         |          none          |
+| `--cfg-confirm-upload`            | Enables user confirmation for upload starting                                                                                          |       `1` or `0`       |          `1`           |
+| `--cfg-img-only`                  | Accept images only                                                                                                                     |       `1` or `0`       |          `0`           |
+| `--cfg-accept`                    | Native file input accept attribute value                                                                                               |      `'image/*'`       |          none          |
+| `--cfg-store`                     | Store files                                                                                                                            |       `1` or `0`       |           -            |
+| `--cfg-camera-mirror`             | Flip camera image                                                                                                                      |       `1` or `0`       |          `0`           |
+| `--cfg-source-list`               | Comma-separated list of file sources                                                                                                   | `'local, url, camera'` |          none          |
+| `--cfg-max-local-file-size-bytes` | Maximum file size in bytes                                                                                                             |           -            |          none          |
+| `--cfg-thumb-size`                | Image thumbnail size                                                                                                                   |          `76`          |          `76`          |
+| `--cfg-show-empty-list`           | Show uploads list when it's empty                                                                                                      |       `1` or `0`       |          `0`           |
+| `--cfg-use-local-image-editor`    | Enable local image editing                                                                                                             |       `1` or `0`       |          `0`           |
+| `--cfg-use-cloud-image-editor`    | Enable cloud image editing                                                                                                             |       `1` or `0`       |          `0`           |
+| `--cfg-remote-tab-session-key`    | Key to revoke Custom OAuth access. See [docs](https://uploadcare.com/docs/start/settings/#project-settings-advanced-oauth) for details |         string         |          none          |
+| `--cfg-cdn-base`                  | Set Custom CNAME. See [docs](https://uploadcare.com/docs/delivery/cdn/#custom-cdn-cname) for details                                   |         string         | `https://ucarecdn.com` |
 
 ## Possible values for the source list
 

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -70,7 +70,7 @@ Any configuration value can be defined and redefined at any level of the DOM tre
 | `--cfg-use-local-image-editor`    | Enable local image editing                                                                                                             |       `1` or `0`       |          `0`           |
 | `--cfg-use-cloud-image-editor`    | Enable cloud image editing                                                                                                             |       `1` or `0`       |          `0`           |
 | `--cfg-remote-tab-session-key`    | Key to revoke Custom OAuth access. See [docs](https://uploadcare.com/docs/start/settings/#project-settings-advanced-oauth) for details |         string         |          none          |
-| `--cfg-cdn-base`                  | Set Custom CNAME. See [docs](https://uploadcare.com/docs/delivery/cdn/#custom-cdn-cname) for details                                   |         string         | `https://ucarecdn.com` |
+| `--cfg-cdn-cname`                 | Set Custom CNAME. See [docs](https://uploadcare.com/docs/delivery/cdn/#custom-cdn-cname) for details                                   |         string         | `https://ucarecdn.com` |
 
 ## Possible values for the source list
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint:css:fix": "stylelint './**/*.css' --fix",
     "lint": "run-s lint:js lint:css",
     "clean:web": "rimraf './web/**/*.{js,css}'",
-    "clean:types": "rimraf './{abstract,blocks,solutions,web,utils,submodules/symbiote}/**/*.{d.ts,d.ts.map}' && rimraf './{!global}.{d.ts,d.ts.map}'",
+    "clean:types": "rimraf './{abstract,blocks,solutions,web,utils,submodules/symbiote}/**/*.{d.ts,d.ts.map}' && rimraf './!(global).{d.ts,d.ts.map}'",
     "clean": "run-s clean:*",
     "format:js": "prettier --write './**/*.{js,cjs}'",
     "format:css": "prettier --write --parser css './**/*.css'",

--- a/solutions/cloud-image-editor/config.css
+++ b/solutions/cloud-image-editor/config.css
@@ -1,0 +1,4 @@
+:where(.uc-cldtr-common),
+:host {
+  --cfg-cdn-base: 'https://ucarecdn.com';
+}

--- a/solutions/cloud-image-editor/config.css
+++ b/solutions/cloud-image-editor/config.css
@@ -1,4 +1,4 @@
 :where(.uc-cldtr-common),
 :host {
-  --cfg-cdn-base: 'https://ucarecdn.com';
+  --cfg-cdn-cname: 'https://ucarecdn.com';
 }

--- a/solutions/cloud-image-editor/index.css
+++ b/solutions/cloud-image-editor/index.css
@@ -1,1 +1,2 @@
+@import url('./config.css');
 @import url('../../blocks/CloudImageEditor/src/css/index.css');

--- a/utils/cdn-utils.js
+++ b/utils/cdn-utils.js
@@ -50,10 +50,14 @@ export function extractFilename(cdnUrl) {
   let pathname = url.pathname;
   let urlFilenameIdx = pathname.lastIndexOf('http');
   let plainFilenameIdx = pathname.lastIndexOf('/');
-  let filename =
-    (urlFilenameIdx > 0 && pathname.slice(urlFilenameIdx)) ||
-    (plainFilenameIdx > 0 && pathname.slice(plainFilenameIdx + 1)) ||
-    '';
+  let filename = '';
+
+  if (urlFilenameIdx > 0) {
+    filename = pathname.slice(urlFilenameIdx) + url.search;
+    url.search = '';
+  } else if (plainFilenameIdx > 0) {
+    filename = pathname.slice(plainFilenameIdx + 1);
+  }
 
   return filename;
 }
@@ -66,10 +70,12 @@ export function trimFilename(cdnUrl) {
   let filename = extractFilename(cdnUrl);
 
   let url = new URL(cdnUrl);
-  let { pathname } = url;
-  let filenameIdx = pathname.lastIndexOf(filename);
-  if (filenameIdx + filename.length === pathname.length) {
-    url.pathname = pathname.substring(0, filenameIdx);
+  let { pathname, search } = url;
+  let pathnameWithSearch = pathname + search;
+  let filenameIdx = pathnameWithSearch.lastIndexOf(filename);
+  if (filenameIdx + filename.length === pathnameWithSearch.length) {
+    url.pathname = pathnameWithSearch.substring(0, filenameIdx);
+    url.search = '';
   }
   return url.toString();
 }
@@ -88,10 +94,10 @@ export const createCdnUrl = (baseCdnUrl, cdnModifiers, filename) => {
 };
 
 /**
- * Create
+ * Create url for an original file on CDN or Proxy CDN
  *
- * @param {String} cdnUrl
- * @param {String} uuidOrFileUrl
+ * @param {String} cdnUrl - URL to get base domain from, any pathname will be stripped
+ * @param {String} uuidOrFileUrl - Uuid for CDN or file URL for Proxy CDN
  * @returns {String}
  */
 export const createOriginalUrl = (cdnUrl, uuidOrFileUrl) => {

--- a/utils/cdn-utils.js
+++ b/utils/cdn-utils.js
@@ -42,15 +42,6 @@ export const createCdnUrlModifiers = (...cdnOperations) => {
 };
 
 /**
- * @param {String} input
- * @returns {String}
- */
-function withTrailingSlash(input) {
-  let url = new URL(input);
-  return url.toString();
-}
-
-/**
  * @param {String} cdnUrl
  * @returns {String}
  */

--- a/utils/cdn-utils.js
+++ b/utils/cdn-utils.js
@@ -7,16 +7,18 @@ export const normalizeCdnOperation = (operation) => {
     return '';
   }
   let str = operation.trim();
+  let start = 0;
+  let end = str.length;
   if (str.startsWith('-/')) {
-    str = str.slice(2);
+    start = 2;
   } else if (str.startsWith('/')) {
-    str = str.slice(1);
+    start = 1;
   }
 
   if (str.endsWith('/')) {
-    str = str.slice(0, str.length - 1);
+    end = str.length - 1;
   }
-  return str;
+  return str.substring(start, end);
 };
 
 /**
@@ -51,13 +53,47 @@ function withTrailingSlash(input) {
 }
 
 /**
- * @param {String} baseUrl
+ * `cdnUrl` is expected to be a:
+ *
+ * - Just `cdnBase` with or without trailing slash
+ * - `cdnBase` + `uuid` + `filename` with trailing slash
+ * - `cdnBase` + `uuid` + `cdnModifiers` + `filename` with trailing slash
+ *
+ * @param {String} cdnUrl
+ * @returns {String}
+ */
+export function extractFilename(cdnUrl) {
+  let protocolSlashesIdx = cdnUrl.indexOf('//');
+  let lastSlashIndex = cdnUrl.lastIndexOf('/');
+  // if last slash is protocol double slash, then it's just a cdnBase
+  if (protocolSlashesIdx + 1 === lastSlashIndex) {
+    return '';
+  }
+  return cdnUrl.substring(lastSlashIndex + 1);
+}
+
+/**
+ * @param {String} cdnUrl
+ * @returns {String}
+ */
+export function trimFilename(cdnUrl) {
+  let filename = extractFilename(cdnUrl);
+  let filenameIdx = cdnUrl.lastIndexOf(filename);
+  if (filenameIdx + filename.length === cdnUrl.length) {
+    return (cdnUrl = cdnUrl.substring(0, filenameIdx));
+  }
+  return cdnUrl;
+}
+
+/**
+ * @param {String} baseCdnUrl
  * @param {String} [cdnModifiers]
  * @param {String} [filename]
  * @returns {String}
  */
-export const createCdnUrl = (baseUrl, cdnModifiers, filename) => {
-  return withTrailingSlash(baseUrl) + (cdnModifiers || '') + (filename || '');
+export const createCdnUrl = (baseCdnUrl, cdnModifiers, filename) => {
+  filename = filename || extractFilename(baseCdnUrl);
+  return withTrailingSlash(trimFilename(baseCdnUrl)) + (cdnModifiers || '') + (filename || '');
 };
 
 /**

--- a/utils/cdn-utils.test.js
+++ b/utils/cdn-utils.test.js
@@ -11,137 +11,177 @@ import {
 
 const falsyValues = ['', undefined, null, false, true, 0, 10];
 
-describe('cdn-utils', () => {
-  describe('cdnOperation', () => {
-    it('should remove trailing and leading delimeters', () => {
-      expect(normalizeCdnOperation('scale_crop/1x1/center')).to.eq('scale_crop/1x1/center');
-      expect(normalizeCdnOperation('/scale_crop/1x1/center/')).to.eq('scale_crop/1x1/center');
-      expect(normalizeCdnOperation('-/scale_crop/1x1/center/')).to.eq('scale_crop/1x1/center');
-    });
-
-    it('should return empty string if falsy value is passed', () => {
-      for (let val of falsyValues) {
-        expect(normalizeCdnOperation(val)).to.eq('');
-      }
-    });
-  });
-  describe('joinCdnOperations', () => {
-    it('should remove trailing and leading delimeters', () => {
-      expect(joinCdnOperations('scale_crop/1x1/center', 'resize')).to.eq('scale_crop/1x1/center/-/resize');
-      expect(joinCdnOperations('/scale_crop/1x1/center/', '/resize/')).to.eq('scale_crop/1x1/center/-/resize');
-      expect(joinCdnOperations('-/scale_crop/1x1/center/', '-/resize/')).to.eq('scale_crop/1x1/center/-/resize');
-      expect(joinCdnOperations('-/scale_crop/1x1/center/', '-/resize/100x/')).to.eq(
-        'scale_crop/1x1/center/-/resize/100x'
-      );
-    });
-
-    it('should return empty string if falsy values are passed', () => {
-      expect(joinCdnOperations(...falsyValues)).to.eq('');
-      expect(joinCdnOperations('scale_crop/1x1/center', ...falsyValues, 'resize/100x')).to.eq(
-        'scale_crop/1x1/center/-/resize/100x'
-      );
-    });
+describe('cdn-utils/normalizeCdnOperation', () => {
+  it('should remove trailing and leading delimeters', () => {
+    expect(normalizeCdnOperation('scale_crop/1x1/center')).to.eq('scale_crop/1x1/center');
+    expect(normalizeCdnOperation('/scale_crop/1x1/center/')).to.eq('scale_crop/1x1/center');
+    expect(normalizeCdnOperation('-/scale_crop/1x1/center/')).to.eq('scale_crop/1x1/center');
   });
 
-  describe('createCdnUrlModifiers', () => {
-    it('should make cdn operations string that could be concatendated with domain', () => {
-      expect(createCdnUrlModifiers('scale_crop/1x1/center', 'resize')).to.eq('-/scale_crop/1x1/center/-/resize/');
-    });
+  it('should return empty string if falsy value is passed', () => {
+    for (let val of falsyValues) {
+      expect(normalizeCdnOperation(val)).to.eq('');
+    }
+  });
+});
 
-    it('should add trailing/leading slash and leading delimeter', () => {
-      expect(createCdnUrlModifiers('scale_crop/1x1/center', 'resize')).to.eq('-/scale_crop/1x1/center/-/resize/');
-      expect(createCdnUrlModifiers('/scale_crop/1x1/center/', '/resize/')).to.eq('-/scale_crop/1x1/center/-/resize/');
-      expect(createCdnUrlModifiers('-/scale_crop/1x1/center/', '-/resize/')).to.eq('-/scale_crop/1x1/center/-/resize/');
-      expect(createCdnUrlModifiers('-/scale_crop/1x1/center/', '-/resize/100x/')).to.eq(
-        '-/scale_crop/1x1/center/-/resize/100x/'
-      );
-    });
-
-    it('return empty string if nothing is passed', () => {
-      expect(createCdnUrlModifiers(...falsyValues)).to.eq('');
-      expect(createCdnUrlModifiers('scale_crop/1x1/center', ...falsyValues, 'resize')).to.eq(
-        '-/scale_crop/1x1/center/-/resize/'
-      );
-    });
+describe('cdn-utils/joinCdnOperations', () => {
+  it('should remove trailing and leading delimeters', () => {
+    expect(joinCdnOperations('scale_crop/1x1/center', 'resize')).to.eq('scale_crop/1x1/center/-/resize');
+    expect(joinCdnOperations('/scale_crop/1x1/center/', '/resize/')).to.eq('scale_crop/1x1/center/-/resize');
+    expect(joinCdnOperations('-/scale_crop/1x1/center/', '-/resize/')).to.eq('scale_crop/1x1/center/-/resize');
+    expect(joinCdnOperations('-/scale_crop/1x1/center/', '-/resize/100x/')).to.eq(
+      'scale_crop/1x1/center/-/resize/100x'
+    );
   });
 
-  describe('createCdnUrl', () => {
-    it('should concatenate domain with cdnModifiers', () => {
-      expect(createCdnUrl('https://ucarecdn.com/', '-/scale_crop/1x1/center/')).to.eq(
-        'https://ucarecdn.com/-/scale_crop/1x1/center/'
-      );
-    });
+  it('should return empty string if falsy values are passed', () => {
+    expect(joinCdnOperations(...falsyValues)).to.eq('');
+    expect(joinCdnOperations('scale_crop/1x1/center', ...falsyValues, 'resize/100x')).to.eq(
+      'scale_crop/1x1/center/-/resize/100x'
+    );
+  });
+});
 
-    it('should accept filename', () => {
-      expect(createCdnUrl('https://ucarecdn.com/', '-/scale_crop/1x1/center/', 'image.jpeg')).to.eq(
-        'https://ucarecdn.com/-/scale_crop/1x1/center/image.jpeg'
-      );
-    });
-
-    it('should use filename from base cdn url', () => {
-      expect(createCdnUrl('https://ucarecdn.com/', '-/scale_crop/1x1/center/', 'image.jpeg')).to.eq(
-        'https://ucarecdn.com/-/scale_crop/1x1/center/image.jpeg'
-      );
-    });
-
-    it('should extract filename from baseCdnUrl and append it to the result', () => {
-      expect(createCdnUrl('https://ucarecdn.com/:uuid/image.jpeg', '-/scale_crop/1x1/center/')).to.eq(
-        'https://ucarecdn.com/:uuid/-/scale_crop/1x1/center/image.jpeg'
-      );
-    });
-
-    it('should override filename from baseCdnUrl with provided', () => {
-      expect(createCdnUrl('https://ucarecdn.com/:uuid/image.jpeg', '-/scale_crop/1x1/center/', 'override.jpeg')).to.eq(
-        'https://ucarecdn.com/:uuid/-/scale_crop/1x1/center/override.jpeg'
-      );
-    });
-
-    it('should add missing trailing slash to the base url', () => {
-      expect(createCdnUrl('https://ucarecdn.com', '-/scale_crop/1x1/center/')).to.eq(
-        'https://ucarecdn.com/-/scale_crop/1x1/center/'
-      );
-    });
+describe('cdn-utils/createCdnUrlModifiers', () => {
+  it('should make cdn operations string that could be concatendated with domain', () => {
+    expect(createCdnUrlModifiers('scale_crop/1x1/center', 'resize')).to.eq('-/scale_crop/1x1/center/-/resize/');
   });
 
-  describe('createOriginalUrl', () => {
-    it('should concatenate cdnBase and uuid', () => {
-      expect(createOriginalUrl('https://ucarecdn.com/', ':uuid')).to.eq('https://ucarecdn.com/:uuid/');
-    });
-
-    it('should add trailing slash to the base url', () => {
-      expect(createOriginalUrl('https://ucarecdn.com', ':uuid')).to.eq('https://ucarecdn.com/:uuid/');
-    });
+  it('should add trailing/leading slash and leading delimeter', () => {
+    expect(createCdnUrlModifiers('scale_crop/1x1/center', 'resize')).to.eq('-/scale_crop/1x1/center/-/resize/');
+    expect(createCdnUrlModifiers('/scale_crop/1x1/center/', '/resize/')).to.eq('-/scale_crop/1x1/center/-/resize/');
+    expect(createCdnUrlModifiers('-/scale_crop/1x1/center/', '-/resize/')).to.eq('-/scale_crop/1x1/center/-/resize/');
+    expect(createCdnUrlModifiers('-/scale_crop/1x1/center/', '-/resize/100x/')).to.eq(
+      '-/scale_crop/1x1/center/-/resize/100x/'
+    );
   });
 
-  describe('extractFilename', () => {
-    it('should extract filename', () => {
-      expect(extractFilename('https://ucarecdn.com/:uuid/image.jpeg')).to.eq('image.jpeg');
-      expect(extractFilename('https://ucarecdn.com/:uuid/-/resize/100x/image.jpeg')).to.eq('image.jpeg');
-    });
+  it('return empty string if nothing is passed', () => {
+    expect(createCdnUrlModifiers(...falsyValues)).to.eq('');
+    expect(createCdnUrlModifiers('scale_crop/1x1/center', ...falsyValues, 'resize')).to.eq(
+      '-/scale_crop/1x1/center/-/resize/'
+    );
+  });
+});
 
-    it('should return empty string if no filename found', () => {
-      expect(extractFilename('https://ucarecdn.com')).to.eq('');
-      expect(extractFilename('https://ucarecdn.com/')).to.eq('');
-      expect(extractFilename('https://ucarecdn.com/:uuid/')).to.eq('');
-      expect(extractFilename('https://ucarecdn.com/:uuid/-/resize/100x/')).to.eq('');
-    });
+describe('cdn-utils/createCdnUrl', () => {
+  it('should concatenate baseCdnUrl with cdnModifiers', () => {
+    expect(createCdnUrl('https://ucarecdn.com/:uuid/', '-/scale_crop/1x1/center/')).to.eq(
+      'https://ucarecdn.com/:uuid/-/scale_crop/1x1/center/'
+    );
   });
 
-  describe('trimFilename', () => {
-    it('should trim filename', () => {
-      expect(trimFilename('https://ucarecdn.com/:uuid/image.jpeg')).to.eq('https://ucarecdn.com/:uuid/');
-      expect(trimFilename('https://ucarecdn.com/:uuid/-/resize/100x/image.jpeg')).to.eq(
-        'https://ucarecdn.com/:uuid/-/resize/100x/'
-      );
-    });
+  it('should accept filename passed as argument', () => {
+    expect(createCdnUrl('https://ucarecdn.com/', '-/scale_crop/1x1/center/', 'image.jpeg')).to.eq(
+      'https://ucarecdn.com/-/scale_crop/1x1/center/image.jpeg'
+    );
+    expect(createCdnUrl('https://domain.ucr.io/', '-/scale_crop/1x1/center/', 'https://domain.com/image.jpg')).to.eq(
+      'https://domain.ucr.io/-/scale_crop/1x1/center/https://domain.com/image.jpg'
+    );
+  });
 
-    it('should return original string if no filename found', () => {
-      expect(trimFilename('https://ucarecdn.com')).to.eq('https://ucarecdn.com');
-      expect(trimFilename('https://ucarecdn.com/')).to.eq('https://ucarecdn.com/');
-      expect(trimFilename('https://ucarecdn.com/:uuid/')).to.eq('https://ucarecdn.com/:uuid/');
-      expect(trimFilename('https://ucarecdn.com/:uuid/-/resize/100x/')).to.eq(
-        'https://ucarecdn.com/:uuid/-/resize/100x/'
-      );
-    });
+  it('should extract filename from baseCdnUrl and append it to the result', () => {
+    expect(createCdnUrl('https://ucarecdn.com/:uuid/image.jpeg', '-/scale_crop/1x1/center/')).to.eq(
+      'https://ucarecdn.com/:uuid/-/scale_crop/1x1/center/image.jpeg'
+    );
+    expect(createCdnUrl('https://domain.ucr.io/https://domain.com/image.jpg', '-/scale_crop/1x1/center/')).to.eq(
+      'https://domain.ucr.io/-/scale_crop/1x1/center/https://domain.com/image.jpg'
+    );
+  });
+
+  it('should override filename from baseCdnUrl with provided', () => {
+    expect(createCdnUrl('https://ucarecdn.com/:uuid/image.jpeg', '-/scale_crop/1x1/center/', 'override.jpeg')).to.eq(
+      'https://ucarecdn.com/:uuid/-/scale_crop/1x1/center/override.jpeg'
+    );
+    expect(
+      createCdnUrl(
+        'https://domain.ucr.io/https://domain.com/image.jpg',
+        '-/scale_crop/1x1/center/',
+        'https://domain.com/override.jpg'
+      )
+    ).to.eq('https://domain.ucr.io/-/scale_crop/1x1/center/https://domain.com/override.jpg');
+  });
+
+  it('should keep cdn modifiers in the baseCdnUrl', () => {
+    expect(createCdnUrl('https://ucarecdn.com/:uuid/-/resize/10x/', '-/scale_crop/1x1/center/')).to.eq(
+      'https://ucarecdn.com/:uuid/-/resize/10x/-/scale_crop/1x1/center/'
+    );
+    expect(
+      createCdnUrl('https://domain.ucr.io/-/resize/10x/https://domain.com/image.jpg', '-/scale_crop/1x1/center/')
+    ).to.eq('https://domain.ucr.io/-/resize/10x/-/scale_crop/1x1/center/https://domain.com/image.jpg');
+  });
+
+  it('should add missing trailing slash to the base url', () => {
+    expect(createCdnUrl('https://ucarecdn.com', '-/scale_crop/1x1/center/')).to.eq(
+      'https://ucarecdn.com/-/scale_crop/1x1/center/'
+    );
+  });
+});
+
+describe('cdn-utils/createOriginalUrl', () => {
+  it('should concatenate cdnBase and uuid/file url', () => {
+    expect(createOriginalUrl('https://ucarecdn.com/', ':uuid')).to.eq('https://ucarecdn.com/:uuid/');
+    expect(createOriginalUrl('https://domain.ucr.io/', 'https://domain.com/image.jpg')).to.eq(
+      'https://domain.ucr.io/https://domain.com/image.jpg'
+    );
+  });
+
+  it('should trim any pathname from cdnBase', () => {
+    expect(createOriginalUrl('https://ucarecdn.com/:old-uuid/-/resize/10x/', ':new-uuid')).to.eq(
+      'https://ucarecdn.com/:new-uuid/'
+    );
+    expect(createOriginalUrl('https://domain.ucr.io/-/resize/10x/', 'https://domain.com/image.jpg')).to.eq(
+      'https://domain.ucr.io/https://domain.com/image.jpg'
+    );
+  });
+
+  it('should add trailing slash to the base url', () => {
+    expect(createOriginalUrl('https://ucarecdn.com', ':uuid')).to.eq('https://ucarecdn.com/:uuid/');
+    expect(createOriginalUrl('https://domain.ucr.io', 'https://domain.com/image.jpg')).to.eq(
+      'https://domain.ucr.io/https://domain.com/image.jpg'
+    );
+  });
+});
+
+describe('cdn-utils/extractFilename', () => {
+  it('should extract filename or file url', () => {
+    expect(extractFilename('https://ucarecdn.com/:uuid/image.jpeg')).to.eq('image.jpeg');
+    expect(extractFilename('https://ucarecdn.com/:uuid/-/resize/100x/image.jpeg')).to.eq('image.jpeg');
+
+    expect(extractFilename('https://domain.ucr.io/https://domain.com/image.jpg')).to.eq('https://domain.com/image.jpg');
+    expect(extractFilename('https://domain.ucr.io/-/resize/100x/https://domain.com/image.jpg')).to.eq(
+      'https://domain.com/image.jpg'
+    );
+  });
+
+  it('should return empty string if no filename found', () => {
+    expect(extractFilename('https://ucarecdn.com')).to.eq('');
+    expect(extractFilename('https://ucarecdn.com/')).to.eq('');
+    expect(extractFilename('https://ucarecdn.com/:uuid/')).to.eq('');
+    expect(extractFilename('https://ucarecdn.com/:uuid/-/resize/100x/')).to.eq('');
+  });
+});
+
+describe('cdn-utils/trimFilename', () => {
+  it('should trim filename or file url', () => {
+    expect(trimFilename('https://ucarecdn.com/:uuid/image.jpeg')).to.eq('https://ucarecdn.com/:uuid/');
+    expect(trimFilename('https://ucarecdn.com/:uuid/-/resize/100x/image.jpeg')).to.eq(
+      'https://ucarecdn.com/:uuid/-/resize/100x/'
+    );
+
+    expect(trimFilename('https://domain.ucr.io/https://domain.com/image.jpg')).to.eq('https://domain.ucr.io/');
+    expect(trimFilename('https://domain.ucr.io/-/resize/https://domain.com/image.jpg')).to.eq(
+      'https://domain.ucr.io/-/resize/'
+    );
+  });
+
+  it('should return original string if no filename found', () => {
+    expect(trimFilename('https://ucarecdn.com')).to.eq('https://ucarecdn.com/');
+    expect(trimFilename('https://ucarecdn.com/')).to.eq('https://ucarecdn.com/');
+    expect(trimFilename('https://ucarecdn.com/:uuid/')).to.eq('https://ucarecdn.com/:uuid/');
+    expect(trimFilename('https://ucarecdn.com/:uuid/-/resize/100x/')).to.eq(
+      'https://ucarecdn.com/:uuid/-/resize/100x/'
+    );
   });
 });

--- a/utils/cdn-utils.test.js
+++ b/utils/cdn-utils.test.js
@@ -5,6 +5,8 @@ import {
   createCdnUrlModifiers,
   createCdnUrl,
   createOriginalUrl,
+  extractFilename,
+  trimFilename,
 } from './cdn-utils.js';
 
 const falsyValues = ['', undefined, null, false, true, 0, 10];
@@ -76,6 +78,24 @@ describe('cdn-utils', () => {
       );
     });
 
+    it('should use filename from base cdn url', () => {
+      expect(createCdnUrl('https://ucarecdn.com/', '-/scale_crop/1x1/center/', 'image.jpeg')).to.eq(
+        'https://ucarecdn.com/-/scale_crop/1x1/center/image.jpeg'
+      );
+    });
+
+    it('should extract filename from baseCdnUrl and append it to the result', () => {
+      expect(createCdnUrl('https://ucarecdn.com/:uuid/image.jpeg', '-/scale_crop/1x1/center/')).to.eq(
+        'https://ucarecdn.com/:uuid/-/scale_crop/1x1/center/image.jpeg'
+      );
+    });
+
+    it('should override filename from baseCdnUrl with provided', () => {
+      expect(createCdnUrl('https://ucarecdn.com/:uuid/image.jpeg', '-/scale_crop/1x1/center/', 'override.jpeg')).to.eq(
+        'https://ucarecdn.com/:uuid/-/scale_crop/1x1/center/override.jpeg'
+      );
+    });
+
     it('should add missing trailing slash to the base url', () => {
       expect(createCdnUrl('https://ucarecdn.com', '-/scale_crop/1x1/center/')).to.eq(
         'https://ucarecdn.com/-/scale_crop/1x1/center/'
@@ -85,14 +105,42 @@ describe('cdn-utils', () => {
 
   describe('createOriginalUrl', () => {
     it('should concatenate cdnBase and uuid', () => {
-      expect(createOriginalUrl('https://ucarecdn.com/', 'e02aa8f3-9d28-4109-8c8c-310ef0f060ac')).to.eq(
-        'https://ucarecdn.com/e02aa8f3-9d28-4109-8c8c-310ef0f060ac/'
-      );
+      expect(createOriginalUrl('https://ucarecdn.com/', ':uuid')).to.eq('https://ucarecdn.com/:uuid/');
     });
 
     it('should add trailing slash to the base url', () => {
-      expect(createOriginalUrl('https://ucarecdn.com', 'e02aa8f3-9d28-4109-8c8c-310ef0f060ac')).to.eq(
-        'https://ucarecdn.com/e02aa8f3-9d28-4109-8c8c-310ef0f060ac/'
+      expect(createOriginalUrl('https://ucarecdn.com', ':uuid')).to.eq('https://ucarecdn.com/:uuid/');
+    });
+  });
+
+  describe('extractFilename', () => {
+    it('should extract filename', () => {
+      expect(extractFilename('https://ucarecdn.com/:uuid/image.jpeg')).to.eq('image.jpeg');
+      expect(extractFilename('https://ucarecdn.com/:uuid/-/resize/100x/image.jpeg')).to.eq('image.jpeg');
+    });
+
+    it('should return empty string if no filename found', () => {
+      expect(extractFilename('https://ucarecdn.com')).to.eq('');
+      expect(extractFilename('https://ucarecdn.com/')).to.eq('');
+      expect(extractFilename('https://ucarecdn.com/:uuid/')).to.eq('');
+      expect(extractFilename('https://ucarecdn.com/:uuid/-/resize/100x/')).to.eq('');
+    });
+  });
+
+  describe('trimFilename', () => {
+    it('should trim filename', () => {
+      expect(trimFilename('https://ucarecdn.com/:uuid/image.jpeg')).to.eq('https://ucarecdn.com/:uuid/');
+      expect(trimFilename('https://ucarecdn.com/:uuid/-/resize/100x/image.jpeg')).to.eq(
+        'https://ucarecdn.com/:uuid/-/resize/100x/'
+      );
+    });
+
+    it('should return original string if no filename found', () => {
+      expect(trimFilename('https://ucarecdn.com')).to.eq('https://ucarecdn.com');
+      expect(trimFilename('https://ucarecdn.com/')).to.eq('https://ucarecdn.com/');
+      expect(trimFilename('https://ucarecdn.com/:uuid/')).to.eq('https://ucarecdn.com/:uuid/');
+      expect(trimFilename('https://ucarecdn.com/:uuid/-/resize/100x/')).to.eq(
+        'https://ucarecdn.com/:uuid/-/resize/100x/'
       );
     });
   });

--- a/utils/cdn-utils.test.js
+++ b/utils/cdn-utils.test.js
@@ -77,17 +77,17 @@ describe('cdn-utils/createCdnUrl', () => {
       'https://ucarecdn.com/-/scale_crop/1x1/center/image.jpeg'
     );
     expect(
-      createCdnUrl('https://domain.ucr.io/', '-/scale_crop/1x1/center/', 'https://domain.com/image.jpg?q=1')
-    ).to.eq('https://domain.ucr.io/-/scale_crop/1x1/center/https://domain.com/image.jpg%3Fq=1');
+      createCdnUrl('https://domain.ucr.io:8080/', '-/scale_crop/1x1/center/', 'https://domain.com/image.jpg?q=1#hash')
+    ).to.eq('https://domain.ucr.io:8080/-/scale_crop/1x1/center/https://domain.com/image.jpg?q=1#hash');
   });
 
   it('should extract filename from baseCdnUrl and append it to the result', () => {
     expect(createCdnUrl('https://ucarecdn.com/:uuid/image.jpeg', '-/scale_crop/1x1/center/')).to.eq(
       'https://ucarecdn.com/:uuid/-/scale_crop/1x1/center/image.jpeg'
     );
-    expect(createCdnUrl('https://domain.ucr.io/https://domain.com/image.jpg?q=1', '-/scale_crop/1x1/center/')).to.eq(
-      'https://domain.ucr.io/-/scale_crop/1x1/center/https://domain.com/image.jpg%3Fq=1'
-    );
+    expect(
+      createCdnUrl('https://domain.ucr.io:8080/https://domain.com/image.jpg?q=1#hash', '-/scale_crop/1x1/center/')
+    ).to.eq('https://domain.ucr.io:8080/-/scale_crop/1x1/center/https://domain.com/image.jpg?q=1#hash');
   });
 
   it('should override filename from baseCdnUrl with provided', () => {
@@ -96,11 +96,11 @@ describe('cdn-utils/createCdnUrl', () => {
     );
     expect(
       createCdnUrl(
-        'https://domain.ucr.io/https://domain.com/image.jpg?q=1',
+        'https://domain.ucr.io:8080/https://domain.com/image.jpg?q=1#hash',
         '-/scale_crop/1x1/center/',
-        'https://domain.com/override.jpg'
+        'https://domain.com/override.jpg?q=2'
       )
-    ).to.eq('https://domain.ucr.io/-/scale_crop/1x1/center/https://domain.com/override.jpg');
+    ).to.eq('https://domain.ucr.io:8080/-/scale_crop/1x1/center/https://domain.com/override.jpg?q=2');
   });
 
   it('should keep cdn modifiers in the baseCdnUrl', () => {
@@ -108,8 +108,11 @@ describe('cdn-utils/createCdnUrl', () => {
       'https://ucarecdn.com/:uuid/-/resize/10x/-/scale_crop/1x1/center/'
     );
     expect(
-      createCdnUrl('https://domain.ucr.io/-/resize/10x/https://domain.com/image.jpg?q=1', '-/scale_crop/1x1/center/')
-    ).to.eq('https://domain.ucr.io/-/resize/10x/-/scale_crop/1x1/center/https://domain.com/image.jpg%3Fq=1');
+      createCdnUrl(
+        'https://domain.ucr.io:8080/-/resize/10x/https://domain.com/image.jpg?q=1#hash',
+        '-/scale_crop/1x1/center/'
+      )
+    ).to.eq('https://domain.ucr.io:8080/-/resize/10x/-/scale_crop/1x1/center/https://domain.com/image.jpg?q=1#hash');
   });
 
   it('should add missing trailing slash to the base url', () => {
@@ -120,27 +123,18 @@ describe('cdn-utils/createCdnUrl', () => {
 });
 
 describe('cdn-utils/createOriginalUrl', () => {
-  it('should concatenate cdnBase and uuid/file url', () => {
+  it('should concatenate cdnBase and uuid', () => {
     expect(createOriginalUrl('https://ucarecdn.com/', ':uuid')).to.eq('https://ucarecdn.com/:uuid/');
-    expect(createOriginalUrl('https://domain.ucr.io/', 'https://domain.com/image.jpg?q=1')).to.eq(
-      'https://domain.ucr.io/https://domain.com/image.jpg%3Fq=1'
-    );
   });
 
   it('should trim any pathname from cdnBase', () => {
     expect(createOriginalUrl('https://ucarecdn.com/:old-uuid/-/resize/10x/', ':new-uuid')).to.eq(
       'https://ucarecdn.com/:new-uuid/'
     );
-    expect(createOriginalUrl('https://domain.ucr.io/-/resize/10x/', 'https://domain.com/image.jpg?q=1')).to.eq(
-      'https://domain.ucr.io/https://domain.com/image.jpg%3Fq=1'
-    );
   });
 
   it('should add trailing slash to the base url', () => {
     expect(createOriginalUrl('https://ucarecdn.com', ':uuid')).to.eq('https://ucarecdn.com/:uuid/');
-    expect(createOriginalUrl('https://domain.ucr.io', 'https://domain.com/image.jpg?q=1')).to.eq(
-      'https://domain.ucr.io/https://domain.com/image.jpg%3Fq=1'
-    );
   });
 });
 
@@ -149,11 +143,11 @@ describe('cdn-utils/extractFilename', () => {
     expect(extractFilename('https://ucarecdn.com/:uuid/image.jpeg')).to.eq('image.jpeg');
     expect(extractFilename('https://ucarecdn.com/:uuid/-/resize/100x/image.jpeg')).to.eq('image.jpeg');
 
-    expect(extractFilename('https://domain.ucr.io/https://domain.com/image.jpg?q=1')).to.eq(
-      'https://domain.com/image.jpg?q=1'
+    expect(extractFilename('https://domain.ucr.io:8080/https://domain.com/image.jpg?q=1#hash')).to.eq(
+      'https://domain.com/image.jpg?q=1#hash'
     );
-    expect(extractFilename('https://domain.ucr.io/-/resize/100x/https://domain.com/image.jpg?q=1')).to.eq(
-      'https://domain.com/image.jpg?q=1'
+    expect(extractFilename('https://domain.ucr.io:8080/-/resize/100x/https://domain.com/image.jpg?q=1#hash')).to.eq(
+      'https://domain.com/image.jpg?q=1#hash'
     );
   });
 
@@ -172,9 +166,11 @@ describe('cdn-utils/trimFilename', () => {
       'https://ucarecdn.com/:uuid/-/resize/100x/'
     );
 
-    expect(trimFilename('https://domain.ucr.io/https://domain.com/image.jpg?q=1')).to.eq('https://domain.ucr.io/');
-    expect(trimFilename('https://domain.ucr.io/-/resize/https://domain.com/image.jpg?q=1')).to.eq(
-      'https://domain.ucr.io/-/resize/'
+    expect(trimFilename('https://domain.ucr.io:8080/https://domain.com/image.jpg?q=1#hash')).to.eq(
+      'https://domain.ucr.io:8080/'
+    );
+    expect(trimFilename('https://domain.ucr.io:8080/-/resize/https://domain.com/image.jpg?q=1#hash')).to.eq(
+      'https://domain.ucr.io:8080/-/resize/'
     );
   });
 

--- a/utils/cdn-utils.test.js
+++ b/utils/cdn-utils.test.js
@@ -76,17 +76,17 @@ describe('cdn-utils/createCdnUrl', () => {
     expect(createCdnUrl('https://ucarecdn.com/', '-/scale_crop/1x1/center/', 'image.jpeg')).to.eq(
       'https://ucarecdn.com/-/scale_crop/1x1/center/image.jpeg'
     );
-    expect(createCdnUrl('https://domain.ucr.io/', '-/scale_crop/1x1/center/', 'https://domain.com/image.jpg')).to.eq(
-      'https://domain.ucr.io/-/scale_crop/1x1/center/https://domain.com/image.jpg'
-    );
+    expect(
+      createCdnUrl('https://domain.ucr.io/', '-/scale_crop/1x1/center/', 'https://domain.com/image.jpg?q=1')
+    ).to.eq('https://domain.ucr.io/-/scale_crop/1x1/center/https://domain.com/image.jpg%3Fq=1');
   });
 
   it('should extract filename from baseCdnUrl and append it to the result', () => {
     expect(createCdnUrl('https://ucarecdn.com/:uuid/image.jpeg', '-/scale_crop/1x1/center/')).to.eq(
       'https://ucarecdn.com/:uuid/-/scale_crop/1x1/center/image.jpeg'
     );
-    expect(createCdnUrl('https://domain.ucr.io/https://domain.com/image.jpg', '-/scale_crop/1x1/center/')).to.eq(
-      'https://domain.ucr.io/-/scale_crop/1x1/center/https://domain.com/image.jpg'
+    expect(createCdnUrl('https://domain.ucr.io/https://domain.com/image.jpg?q=1', '-/scale_crop/1x1/center/')).to.eq(
+      'https://domain.ucr.io/-/scale_crop/1x1/center/https://domain.com/image.jpg%3Fq=1'
     );
   });
 
@@ -96,7 +96,7 @@ describe('cdn-utils/createCdnUrl', () => {
     );
     expect(
       createCdnUrl(
-        'https://domain.ucr.io/https://domain.com/image.jpg',
+        'https://domain.ucr.io/https://domain.com/image.jpg?q=1',
         '-/scale_crop/1x1/center/',
         'https://domain.com/override.jpg'
       )
@@ -108,8 +108,8 @@ describe('cdn-utils/createCdnUrl', () => {
       'https://ucarecdn.com/:uuid/-/resize/10x/-/scale_crop/1x1/center/'
     );
     expect(
-      createCdnUrl('https://domain.ucr.io/-/resize/10x/https://domain.com/image.jpg', '-/scale_crop/1x1/center/')
-    ).to.eq('https://domain.ucr.io/-/resize/10x/-/scale_crop/1x1/center/https://domain.com/image.jpg');
+      createCdnUrl('https://domain.ucr.io/-/resize/10x/https://domain.com/image.jpg?q=1', '-/scale_crop/1x1/center/')
+    ).to.eq('https://domain.ucr.io/-/resize/10x/-/scale_crop/1x1/center/https://domain.com/image.jpg%3Fq=1');
   });
 
   it('should add missing trailing slash to the base url', () => {
@@ -122,8 +122,8 @@ describe('cdn-utils/createCdnUrl', () => {
 describe('cdn-utils/createOriginalUrl', () => {
   it('should concatenate cdnBase and uuid/file url', () => {
     expect(createOriginalUrl('https://ucarecdn.com/', ':uuid')).to.eq('https://ucarecdn.com/:uuid/');
-    expect(createOriginalUrl('https://domain.ucr.io/', 'https://domain.com/image.jpg')).to.eq(
-      'https://domain.ucr.io/https://domain.com/image.jpg'
+    expect(createOriginalUrl('https://domain.ucr.io/', 'https://domain.com/image.jpg?q=1')).to.eq(
+      'https://domain.ucr.io/https://domain.com/image.jpg%3Fq=1'
     );
   });
 
@@ -131,15 +131,15 @@ describe('cdn-utils/createOriginalUrl', () => {
     expect(createOriginalUrl('https://ucarecdn.com/:old-uuid/-/resize/10x/', ':new-uuid')).to.eq(
       'https://ucarecdn.com/:new-uuid/'
     );
-    expect(createOriginalUrl('https://domain.ucr.io/-/resize/10x/', 'https://domain.com/image.jpg')).to.eq(
-      'https://domain.ucr.io/https://domain.com/image.jpg'
+    expect(createOriginalUrl('https://domain.ucr.io/-/resize/10x/', 'https://domain.com/image.jpg?q=1')).to.eq(
+      'https://domain.ucr.io/https://domain.com/image.jpg%3Fq=1'
     );
   });
 
   it('should add trailing slash to the base url', () => {
     expect(createOriginalUrl('https://ucarecdn.com', ':uuid')).to.eq('https://ucarecdn.com/:uuid/');
-    expect(createOriginalUrl('https://domain.ucr.io', 'https://domain.com/image.jpg')).to.eq(
-      'https://domain.ucr.io/https://domain.com/image.jpg'
+    expect(createOriginalUrl('https://domain.ucr.io', 'https://domain.com/image.jpg?q=1')).to.eq(
+      'https://domain.ucr.io/https://domain.com/image.jpg%3Fq=1'
     );
   });
 });
@@ -149,9 +149,11 @@ describe('cdn-utils/extractFilename', () => {
     expect(extractFilename('https://ucarecdn.com/:uuid/image.jpeg')).to.eq('image.jpeg');
     expect(extractFilename('https://ucarecdn.com/:uuid/-/resize/100x/image.jpeg')).to.eq('image.jpeg');
 
-    expect(extractFilename('https://domain.ucr.io/https://domain.com/image.jpg')).to.eq('https://domain.com/image.jpg');
-    expect(extractFilename('https://domain.ucr.io/-/resize/100x/https://domain.com/image.jpg')).to.eq(
-      'https://domain.com/image.jpg'
+    expect(extractFilename('https://domain.ucr.io/https://domain.com/image.jpg?q=1')).to.eq(
+      'https://domain.com/image.jpg?q=1'
+    );
+    expect(extractFilename('https://domain.ucr.io/-/resize/100x/https://domain.com/image.jpg?q=1')).to.eq(
+      'https://domain.com/image.jpg?q=1'
     );
   });
 
@@ -170,8 +172,8 @@ describe('cdn-utils/trimFilename', () => {
       'https://ucarecdn.com/:uuid/-/resize/100x/'
     );
 
-    expect(trimFilename('https://domain.ucr.io/https://domain.com/image.jpg')).to.eq('https://domain.ucr.io/');
-    expect(trimFilename('https://domain.ucr.io/-/resize/https://domain.com/image.jpg')).to.eq(
+    expect(trimFilename('https://domain.ucr.io/https://domain.com/image.jpg?q=1')).to.eq('https://domain.ucr.io/');
+    expect(trimFilename('https://domain.ucr.io/-/resize/https://domain.com/image.jpg?q=1')).to.eq(
       'https://domain.ucr.io/-/resize/'
     );
   });


### PR DESCRIPTION
- New `--cfg-cdn-base` config property
- Also, separate config for `cloud-image-editor` as a solution
- Improvements to cdn-utils, now it supports proxy urls with search queries and hash fragments